### PR TITLE
Write newline when setting GitHub output

### DIFF
--- a/src/docker_python_nodejs/build_matrix.py
+++ b/src/docker_python_nodejs/build_matrix.py
@@ -25,7 +25,7 @@ def _github_action_set_output(key: str, value: str) -> None:
         sys.exit(1)
 
     with Path(GITHUB_OUTPUT).open("a") as fp:
-        fp.write(f"{key}={value}")
+        fp.write(f"{key}={value}\n")
 
 
 def build_matrix(new_or_updated: "list[BuildVersion]", ci_event: str) -> None:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -36,14 +36,25 @@ def build_version_fixture() -> BuildVersion:
     )
 
 
-@pytest.mark.enable_socket()
+@responses.activate
 def test_scrape_supported_python_versions() -> None:
+    html = """
+    <table id="supported-versions">
+      <tbody>
+        <tr><td>3.12</td><td></td><td></td><td>2000-01-01</td><td>2999-01-01</td><td></td></tr>
+      </tbody>
+    </table>
+    """
+    responses.add(
+        method="GET",
+        url="https://devguide.python.org/versions/",
+        body=html,
+        status=200,
+    )
     versions = scrape_supported_python_versions()
-    assert len(versions) > 0
-    first_version = versions[0]
-    assert first_version.version
-    assert first_version.start
-    assert first_version.end
+    assert versions == [
+        SupportedVersion(version="3.12", start="2000-01-01", end="2999-01-01")
+    ]
 
 
 @responses.activate

--- a/tests/test_build_matrix.py
+++ b/tests/test_build_matrix.py
@@ -1,0 +1,12 @@
+from docker_python_nodejs import build_matrix
+
+
+def test_github_action_set_output_splits_newlines(tmp_path, monkeypatch):
+    output_file = tmp_path / "out.txt"
+    monkeypatch.setattr(build_matrix, "GITHUB_OUTPUT", str(output_file))
+
+    build_matrix._github_action_set_output("FIRST", "1")
+    build_matrix._github_action_set_output("SECOND", "2")
+
+    lines = output_file.read_text().splitlines()
+    assert lines == ["FIRST=1", "SECOND=2"]


### PR DESCRIPTION
## Summary
- ensure `_github_action_set_output` appends a newline to each key/value pair
- mock out `scrape_supported_python_versions` network call
- add regression test checking outputs split on newlines

## Testing
- `uv run pytest`


------