### PR TITLE
chore: ignore SLF001 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ ignore = [
 target-version = "py312"
 
 [tool.ruff.per-file-ignores]
-"**/test*.py" = ["S101"]
+"**/test*.py" = ["S101", "SLF001"]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
## Summary
- ignore S101 and SLF001 in test files

## Testing
- `./.venv/bin/pre-commit run --files pyproject.toml tests/test_build_matrix.py` *(fails: unable to access https://github.com/astral-sh/ruff-pre-commit/)*

------
https://chatgpt.com/codex/tasks/task_e_68bb893f9d6483318e292f4a93f3b228