### PR TITLE
vendor ruff pre-commit hooks for offline use

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,17 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.0
+  - repo: local
     hooks:
       - id: ruff
+        name: ruff
+        entry: vendor/ruff-pre-commit/ruff.sh
+        language: script
+        types: [python]
         args: [--fix]
       - id: ruff-format
+        name: ruff-format
+        entry: vendor/ruff-pre-commit/ruff-format.sh
+        language: script
+        types: [python]
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.29.4
     hooks:

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ ninja update-versions
 ninja show-versions
 ```
 
+### Offline pre-commit
+
+This repository vendors the Ruff pre-commit hooks in `vendor/ruff-pre-commit` and references them locally in `.pre-commit-config.yaml`. As a result, the lint and format checks can run without network access:
+
+```bash
+uv run pre-commit install
+uv run pre-commit run --all-files
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/vendor/ruff-pre-commit/LICENSE
+++ b/vendor/ruff-pre-commit/LICENSE
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/ruff-pre-commit/README.md
+++ b/vendor/ruff-pre-commit/README.md
@@ -1,0 +1,2 @@
+This directory vendors the minimal Ruff pre-commit hooks so that pre-commit can run without network access.
+The scripts wrap `uv run ruff` and `uv run ruff format` to use the project's pinned Ruff.

--- a/vendor/ruff-pre-commit/ruff-format.sh
+++ b/vendor/ruff-pre-commit/ruff-format.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+uv run ruff format "$@"

--- a/vendor/ruff-pre-commit/ruff.sh
+++ b/vendor/ruff-pre-commit/ruff.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+uv run ruff "$@"


### PR DESCRIPTION
## Summary
- vendor minimal `ruff-pre-commit` hooks so linting can run offline
- run ruff via local scripts and update pre-commit config
- document offline pre-commit workflow in README

## Testing
- `uv run pre-commit run --all-files` *(fails: unable to fetch https://github.com/python-jsonschema/check-jsonschema/)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8934d80c8331991b1b2590a0639a