### PR TITLE
feat: add retryable HTTP session

### DIFF
--- a/src/docker_python_nodejs/docker_hub.py
+++ b/src/docker_python_nodejs/docker_hub.py
@@ -1,6 +1,6 @@
 from typing import TypedDict
 
-import requests
+from .http import get_session
 
 
 class DockerImageDict(TypedDict):
@@ -45,7 +45,8 @@ class DockerTagResponse(TypedDict):
 
 def fetch_tags(package: str, page: int = 1) -> list[DockerTagDict]:
     """Fetch available docker tags."""
-    result = requests.get(
+    session = get_session()
+    result = session.get(
         f"https://registry.hub.docker.com/v2/namespaces/library/repositories/{package}/tags",
         params={"page": page, "page_size": 100},
         timeout=10.0,

--- a/src/docker_python_nodejs/http.py
+++ b/src/docker_python_nodejs/http.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import requests
+from functools import lru_cache
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+@lru_cache
+def get_session() -> requests.Session:
+    """Return a requests session with retry logic configured."""
+    session = requests.Session()
+    retry = Retry(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["GET"],
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session

--- a/src/docker_python_nodejs/nodejs_versions.py
+++ b/src/docker_python_nodejs/nodejs_versions.py
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Mapping
 from typing import TypedDict
 
-import requests
+from .http import get_session
 
 todays_date = datetime.datetime.now(datetime.UTC).date().isoformat()
 
@@ -16,7 +16,8 @@ class NodeRelease(TypedDict):
 def fetch_node_releases() -> list[NodeRelease]:
     """Fetch offical node releases"""
     url = "https://nodejs.org/dist/index.json"
-    res = requests.get(url, timeout=10.0)
+    session = get_session()
+    res = session.get(url, timeout=10.0)
     res.raise_for_status()
     data: list[NodeRelease] = res.json()
     return data
@@ -24,7 +25,8 @@ def fetch_node_releases() -> list[NodeRelease]:
 
 def fetch_node_unofficial_releases() -> list[NodeRelease]:
     url = "https://unofficial-builds.nodejs.org/download/release/index.json"
-    res = requests.get(url, timeout=10.0)
+    session = get_session()
+    res = session.get(url, timeout=10.0)
     res.raise_for_status()
     data: list[NodeRelease] = res.json()
     return data
@@ -40,7 +42,8 @@ class ReleaseScheduleItem(TypedDict):
 
 def fetch_nodejs_release_schedule() -> Mapping[str, ReleaseScheduleItem]:
     """Download list of official releases, skipping unreleased and unsupported versions"""
-    res = requests.get("https://raw.githubusercontent.com/nodejs/Release/master/schedule.json", timeout=10.0)
+    session = get_session()
+    res = session.get("https://raw.githubusercontent.com/nodejs/Release/master/schedule.json", timeout=10.0)
     res.raise_for_status()
     release_schedule: Mapping[str, ReleaseScheduleItem] = res.json()
     return release_schedule

--- a/src/docker_python_nodejs/versions.py
+++ b/src/docker_python_nodejs/versions.py
@@ -5,13 +5,13 @@ import logging
 import re
 from dataclasses import dataclass
 
-import requests
 from bs4 import BeautifulSoup
 from semver.version import Version
 
 from docker_python_nodejs.readme import format_supported_versions
 
 from .docker_hub import DockerImageDict, DockerTagDict, fetch_tags
+from .http import get_session
 from .nodejs_versions import (
     fetch_node_releases,
     fetch_node_unofficial_releases,
@@ -109,7 +109,8 @@ def scrape_supported_python_versions() -> list[SupportedVersion]:
     versions = []
     version_table_row_selector = "#supported-versions tbody tr"
 
-    res = requests.get("https://devguide.python.org/versions/", timeout=10.0)
+    session = get_session()
+    res = session.get("https://devguide.python.org/versions/", timeout=10.0)
     res.raise_for_status()
 
     soup = BeautifulSoup(res.text, "html.parser")

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -1,0 +1,87 @@
+import pytest
+import responses
+
+from docker_python_nodejs.docker_hub import fetch_tags
+from docker_python_nodejs.nodejs_versions import (
+    fetch_node_releases,
+    fetch_node_unofficial_releases,
+    fetch_nodejs_release_schedule,
+)
+from docker_python_nodejs.versions import scrape_supported_python_versions
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    ("func", "url", "payload"),
+    [
+        (
+            fetch_node_releases,
+            "https://nodejs.org/dist/index.json",
+            [{"version": "v1.0.0", "date": "2000-01-01", "files": []}],
+        ),
+        (
+            fetch_node_unofficial_releases,
+            "https://unofficial-builds.nodejs.org/download/release/index.json",
+            [{"version": "v1.0.0", "date": "2000-01-01", "files": []}],
+        ),
+    ],
+)
+def test_node_release_fetchers_retry(func, url, payload) -> None:
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, json=payload, status=200)
+    assert func() == payload
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_fetch_nodejs_release_schedule_retry() -> None:
+    url = "https://raw.githubusercontent.com/nodejs/Release/master/schedule.json"
+    data = {
+        "v1": {
+            "start": "2000-01-01",
+            "lts": "2000-06-01",
+            "maintenance": "2000-07-01",
+            "end": "2100-01-01",
+            "codename": "foo",
+        }
+    }
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, json=data, status=200)
+    assert fetch_nodejs_release_schedule() == data
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_fetch_tags_retry() -> None:
+    url = "https://registry.hub.docker.com/v2/namespaces/library/repositories/python/tags?page=1&page_size=100"
+    result = {
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [{"name": "3.11.4-bookworm", "images": []}],
+    }
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, json=result, status=200)
+    assert fetch_tags("python") == result["results"]
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_scrape_supported_python_versions_retry() -> None:
+    url = "https://devguide.python.org/versions/"
+    html = """
+    <table id='supported-versions'>
+      <tbody>
+        <tr>
+          <td>3.11</td><td></td><td></td>
+          <td>2000-01-01</td><td>2100-01-01</td><td></td>
+        </tr>
+      </tbody>
+    </table>
+    """
+    responses.add(responses.GET, url, status=500)
+    responses.add(responses.GET, url, body=html, status=200)
+    versions = scrape_supported_python_versions()
+    assert len(versions) == 1
+    assert versions[0].version == "3.11"
+    assert len(responses.calls) == 2


### PR DESCRIPTION
## Summary
- add reusable HTTP session with retry logic
- use retry session for fetching tags, Node.js releases, and scraping Python versions
- test retry behavior on transient failures

## Testing
- `uv run pre-commit run -a` *(fails: command can't access plugin repository)*
- `uv run pytest` *(fails: ProxyError to devguide.python.org)*
- `uv run pytest tests/test_http_retry.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb85692df48331887ecff85392631a