### PR TITLE
Handle missing versions file gracefully

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -17,6 +17,7 @@ from docker_python_nodejs.versions import (
     fetch_supported_nodejs_versions,
     scrape_supported_python_versions,
 )
+import docker_python_nodejs.versions as versions
 
 
 @pytest.fixture(name="build_version")
@@ -251,3 +252,18 @@ def test_decide_nodejs_versions(
     versions = decide_nodejs_versions(distros, supported_node_versions)
 
     assert len(supported_node_versions) * len(distros) == len(versions)
+
+
+def test_load_versions_no_file(monkeypatch, tmp_path) -> None:
+    path = tmp_path / "versions.json"
+    monkeypatch.setattr(versions, "VERSIONS_PATH", path)
+
+    assert versions.load_versions() == []
+
+
+def test_find_new_or_updated_no_file(monkeypatch, tmp_path, build_version: BuildVersion) -> None:
+    path = tmp_path / "versions.json"
+    monkeypatch.setattr(versions, "VERSIONS_PATH", path)
+
+    result = versions.find_new_or_updated([build_version])
+    assert result == [build_version]


### PR DESCRIPTION
## Summary
- Avoid crashing when `versions.json` is missing by returning an empty list
- Treat all provided versions as new when no current versions are present
- Test behaviour when the versions file is absent

## Testing
- `pytest tests/test_all.py::test_load_versions_no_file -q` *(fails: unrecognized arguments: --disable-socket)*
- `pre-commit run --files src/docker_python_nodejs/versions.py tests/test_all.py` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8567cadc8331be60fec14c43a2c8