### PR TITLE
refactor: compute dates inside functions

### DIFF
--- a/src/docker_python_nodejs/nodejs_versions.py
+++ b/src/docker_python_nodejs/nodejs_versions.py
@@ -1,10 +1,7 @@
-import datetime
 from collections.abc import Mapping
 from typing import TypedDict
 
 import requests
-
-todays_date = datetime.datetime.now(datetime.UTC).date().isoformat()
 
 
 class NodeRelease(TypedDict):

--- a/src/docker_python_nodejs/versions.py
+++ b/src/docker_python_nodejs/versions.py
@@ -19,8 +19,6 @@ from .nodejs_versions import (
 )
 from .settings import DEFAULT_DISTRO, DEFAULT_PLATFORMS, DISTROS, VERSIONS_PATH
 
-todays_date = datetime.datetime.now(datetime.UTC).date().isoformat()
-
 
 logger = logging.getLogger("dpn")
 
@@ -106,6 +104,7 @@ def _latest_patch(tags: list[DockerTagDict], ver: str, distro: str) -> str | Non
 
 def scrape_supported_python_versions() -> list[SupportedVersion]:
     """Scrape supported python versions (risky)."""
+    todays_date = datetime.datetime.now(datetime.UTC).date().isoformat()
     versions = []
     version_table_row_selector = "#supported-versions tbody tr"
 
@@ -156,10 +155,13 @@ def decide_python_versions(distros: list[str], supported_versions: list[Supporte
 
 def fetch_supported_nodejs_versions() -> list[SupportedVersion]:
     release_schedule = fetch_nodejs_release_schedule()
+    todays_date = datetime.datetime.now(datetime.UTC).date().isoformat()
     versions = []
     for ver, detail in release_schedule.items():
         if detail["start"] <= todays_date <= detail["end"]:
-            versions.append(SupportedVersion(version=ver, start=detail["start"], end=detail["end"]))
+            versions.append(
+                SupportedVersion(version=ver, start=detail["start"], end=detail["end"])
+            )
 
     return versions
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime
 import json
 from pathlib import Path
 from typing import Any
@@ -246,7 +247,11 @@ def test_decide_nodejs_versions(
         url="https://unofficial-builds.nodejs.org/download/release/index.json",
         json=node_unofficial_releases,
     )
-    supported_node_versions = fetch_supported_nodejs_versions()
+    with mock.patch(
+        "docker_python_nodejs.versions.datetime.datetime", wraps=datetime.datetime
+    ) as mock_datetime:
+        mock_datetime.now.return_value = datetime.datetime(2024, 5, 1, tzinfo=datetime.UTC)
+        supported_node_versions = fetch_supported_nodejs_versions()
     distros = ["bookworm", "alpine"]
     versions = decide_nodejs_versions(distros, supported_node_versions)
 


### PR DESCRIPTION
## Summary
- remove module-level `todays_date` constants
- compute the current date inside version helpers
- mock `datetime` in tests to keep expectations stable

## Testing
- `uv run pre-commit run --files src/docker_python_nodejs/nodejs_versions.py src/docker_python_nodejs/versions.py tests/test_all.py` *(fails: fatal: unable to access 'https://github.com/astral-sh/ruff-pre-commit/': CONNECT tunnel failed, response 403)*
- `uv run pytest tests/test_all.py::test_decide_nodejs_versions`
- `uv run pytest tests/test_all.py::test_scrape_supported_python_versions` *(fails: HTTPSConnectionPool(host='devguide.python.org', port=443): Max retries exceeded with url: /versions/ (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_68bb85658a648331b3306a8b48d049ca